### PR TITLE
Fix error on chown() missing 1 required argument:

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -464,7 +464,7 @@ def _extractall(self, path=".", members=None):
     for tarinfo in directories:
         dirpath = os.path.join(path, tarinfo.name)
         try:
-            self.chown(tarinfo, dirpath)
+            self.chown(tarinfo, dirpath, None)
             self.utime(tarinfo, dirpath)
             self.chmod(tarinfo, dirpath)
         except ExtractError:


### PR DESCRIPTION
TypeError: chown() missing 1 required positional argument: 'numeric_owner'